### PR TITLE
chore: update electron version due to a windows vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -510,9 +510,9 @@
       }
     },
     "electron": {
-      "version": "1.6.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.6.11.tgz",
-      "integrity": "sha1-vnnA69zv7bW/KBF0CYAPpTus7/o=",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
+      "integrity": "sha1-mTtqp54OeafPzDafTIE/vZoLCNk=",
       "dev": true,
       "requires": {
         "@types/node": "7.0.52",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "server": "http-server -a localhost -p 8000 -c-1"
   },
   "devDependencies": {
-    "electron": "1.6.11",
+    "electron": "^1.7.11",
     "grunt": "^0.4.5",
     "grunt-contrib-jshint": "^0.12.0",
     "grunt-contrib-sass": "^0.9.2",


### PR DESCRIPTION
Update electron to 1.7.11 due to a windows vulnerability, namely:
- [CVE-2018-1000006](https://electronjs.org/blog/protocol-handler-fix)